### PR TITLE
Change '#' to '_' so sqlalchemy stops complaining

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -43,7 +43,7 @@ class SqlExtension(Extension):
             else:
                 break
         if not name:
-            name = "bind#0"
+            name = "bind_0"
         return name
 
     def filter_stream(self, stream):


### PR DESCRIPTION
When using sqlachemy, bind parameters named with a '#' raise errors. Apparently this is due to sqlalchemy using '#' as a separator. Instead of expecting a bind parameter named 'bind#0_{n}', it looks for a bind parameter named ONLY 'bind'

"""sqlalchemy.exc.StatementError: (sqlalchemy.exc.InvalidRequestError) A value is required for bind parameter 'bind'"""